### PR TITLE
chore: Activating webhooks and smaller things

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,8 +21,8 @@
 #@   "slack_resource",
 #@   "gcr_resource_type",
 #@   "slack_resource_type",
+#@   "npm_resource_type",
 #@   "charts_repo_resource")
-
 
 #@ def release():
 name: release
@@ -136,11 +136,11 @@ jobs:
 - #@ open_charts_pr()
 
 resources:
-- #@ repo_resource()
+- #@ repo_resource(webhook=True)
 - #@ nodejs_deps_resource(pckgMgr="pnpm")
 - #@ version_resource()
 - #@ versioned_image_resource()
-- #@ pipeline_tasks_resource()
+- #@ pipeline_tasks_resource(webhook=True)
 - #@ deps_version_resource()
 - #@ bundled_deps_resource()
 - #@ slack_resource()
@@ -152,7 +152,5 @@ resources:
 resource_types:
 - #@ gcr_resource_type()
 - #@ slack_resource_type()
-- name: npm
-  type: docker-image
-  source:
-    repository: timotto/concourse-npm-resource
+- #@ npm_resource_type()
+

--- a/ci/repipe
+++ b/ci/repipe
@@ -7,7 +7,7 @@ if [[ $(which ytt) == "" ]]; then
   exit 1
 fi
 
-target="${FLY_TARGET:-galoy}"
+target="${FLY_TARGET:-ciblink}"
 team=dev
 
 TMPDIR=""

--- a/src/relay.js
+++ b/src/relay.js
@@ -95,6 +95,11 @@ function relay_send(ev, url) {
     return new Promise(async (resolve, reject) => {
       const relay = relayInit(url)
       try {
+          // Set up the connect handler before connecting
+          relay.on('connect', () => {
+            console.log(`connected to ${relay.url}`)
+          })
+
           await relay.connect()
 
           let pub = relay.publish(ev)
@@ -107,20 +112,22 @@ function relay_send(ev, url) {
             console.log(`failed to publish to ${relay.url}: ${reason}`)
             resolve(true)
           })
-          pub.on('seen', () => {
-            console.log(`we saw the event on ${relay.url}`)
-            resolve(true)
-          })
+          // commented as this is not a proper event and therefore results in: 
+          // TypeError: Cannot read properties of undefined (reading 'push')
+          // at Object.on (/app/node_modules/.pnpm/nostr-tools@1.4.2/node_modules/nostr-tools/lib/nostr.cjs.js:524:34)
+          // at file:///app/src/relay.js:110:15
+          // at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
+          // pub.on('seen', () => {
+          //   console.log(`we saw the event on ${relay.url}`)
+          //   resolve(true)
+          // })
 
-          relay.on('connect', () => {
-            console.log(`connected to ${relay.url}`)
-          })
       } catch (err) {
         console.log(err)
         reject(err)
       }
-      })
-  }
+    })
+}
   
   async function send_note(urls, _ , ev)
   {


### PR DESCRIPTION
This is also fixing:

```
🚀 "galoy-nostr" trigger ready
Sending lightning zap note b07c7a9279bb658a724f046274a6b5b018c690e6cf369d9ed683ed9d0dcad6fb to wss://nos.lol/, wss://relay.damus.io/
TypeError: Cannot read properties of undefined (reading 'push')
    at Object.on (/app/node_modules/.pnpm/nostr-tools@1.4.2/node_modules/nostr-tools/lib/nostr.cjs.js:524:34)
    at file:///app/src/relay.js:110:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
TypeError: Cannot read properties of undefined (reading 'push')
    at Object.on (/app/node_modules/.pnpm/nostr-tools@1.4.2/node_modules/nostr-tools/lib/nostr.cjs.js:524:34)
    at file:///app/src/relay.js:110:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
wss://nos.lol/ has accepted our event
TypeError: Cannot read properties of undefined (reading 'push')
    at Object.on (/app/node_modules/.pnpm/nostr-tools@1.4.2/node_modules/nostr-tools/lib/nostr.cjs.js:524:34)
    at file:///app/src/relay.js:110:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
TypeError: Cannot read properties of undefined (reading 'push')
    at Object.on (/app/node_modules/.pnpm/nostr-tools@1.4.2/node_modules/nostr-tools/lib/nostr.cjs.js:524:34)
    at file:///app/src/relay.js:110:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
done
wss://relay.damus.io/ has accepted our event
kim_blinkbtc_com@galoy-staging-bastion:~$
```

which now looks like this:
```
🚀 "galoy-nostr" trigger ready
Sending lightning zap note efd6bb9184de80de75fc587dd1dd6c1d8469f879ac460f903de04a56569d7dc0 to wss://nos.lol/, wss://relay.damus.io/
connected to wss://nos.lol/
wss://nos.lol/ has accepted our event
connected to wss://relay.damus.io/
wss://relay.damus.io/ has accepted our event
done
```
