### PR TITLE
chore: fix github_token

### DIFF
--- a/ci/values.yml
+++ b/ci/values.yml
@@ -3,7 +3,7 @@
 git_uri: git@github.com:blinkbitcoin/blink-nostr.git
 git_branch: main
 github_private_key: ((github-blinkbitcoin.private_key))
-github_token: ((github.api_token))
+github_token: ((github-blinkbitcoin.api_token))
 
 docker_registry: us.gcr.io/galoy-org
 docker_registry_user: ((docker-creds.username))

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -1,7 +1,7 @@
 #@data/values
 ---
 git_uri: git@github.com:blinkbitcoin/blink-nostr.git
-git_branch: main
+git_branch: kn/fix_release
 github_private_key: ((github-blinkbitcoin.private_key))
 github_token: ((github-blinkbitcoin.api_token))
 


### PR DESCRIPTION
It prevented the gh_release job in https://ci.blink.sv/teams/dev/pipelines/blink-nostr/jobs/release/builds/2