### PR TITLE
chore: refactor to use galoy token for openChartPr and blinkbitcoin token for gh-release

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -117,7 +117,8 @@ plan:
         - name: edge-image
         - name: charts-repo
       params:
-        GH_TOKEN: #@ data.values.github_token
+        #! change here:
+        GH_TOKEN: #@ data.values.github_galoy_token
         BRANCH: #@ data.values.git_charts_branch
         BOT_BRANCH: #@ data.values.git_charts_bot_branch
         #! change here

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -3,7 +3,8 @@
 git_uri: git@github.com:blinkbitcoin/blink-nostr.git
 git_branch: main
 github_private_key: ((github-blinkbitcoin.private_key))
-github_token: ((github.api_token))
+github_token: ((github-blinkbitcoin.api_token))
+github_galoy_token: ((github.api_token))
 
 docker_registry: us.gcr.io/galoy-org
 docker_registry_user: ((docker-creds.username))


### PR DESCRIPTION
So it should be using the blinkbitcoinbot for creating a release but it can't use the blinkbitcoinbot for creating a PR in the charts repo of the GaloyMoney org (because of missing perms).

So this PR uses different api_token for each job. 